### PR TITLE
Added a "tsf_copy" function

### DIFF
--- a/tsf.h
+++ b/tsf.h
@@ -1093,12 +1093,14 @@ TSFDEF tsf* tsf_load(struct tsf_stream* stream)
 TSFDEF tsf* tsf_copy(tsf* f)
 {
 	tsf* res = TSF_NULL;
-
-	res = (tsf*)TSF_MALLOC(sizeof(tsf));
-	memcpy(res, f, sizeof(tsf));
-	res->voices = TSF_NULL;
-	res->voiceNum = 0;
-	++(*res->refCount);
+	if (f)
+	{
+		res = (tsf*)TSF_MALLOC(sizeof(tsf));
+		TSF_MEMCPY(res, f, sizeof(tsf));
+		res->voices = TSF_NULL;
+		res->voiceNum = 0;
+		++(*res->refCount);
+	}
 
 	return res;
 }


### PR DESCRIPTION
This function duplicates a tsf instance which shares everything except "voices" and "voiceNum".

I need more than one tsf instance with separated note control (on/off), although they may sometimes play with same `preset` instrument and `key`.
