### PR TITLE
Fix conditions evaluating based on uninitialized memory

### DIFF
--- a/tsf.h
+++ b/tsf.h
@@ -1564,7 +1564,7 @@ static void tsf_channel_applypitch(tsf* f, int channel, struct tsf_channel* c)
 	struct tsf_voice *v, *vEnd;
 	float pitchShift = (c->pitchWheel == 8192 ? c->tuning : ((c->pitchWheel / 16383.0f * c->pitchRange * 2.0f) - c->pitchRange + c->tuning));
 	for (v = f->voices, vEnd = v + f->voiceNum; v != vEnd; v++)
-		if (v->playingChannel == channel && v->playingPreset != -1)
+		if (v->playingPreset != -1 && v->playingChannel == channel)
 			tsf_voice_calcpitchratio(v, pitchShift, f->outSampleRate);
 }
 
@@ -1630,7 +1630,7 @@ TSFDEF void tsf_channel_set_volume(tsf* f, int channel, float volume)
 	struct tsf_voice *v, *vEnd;
 	if (gainDBChange == 0) return;
 	for (v = f->voices, vEnd = v + f->voiceNum; v != vEnd; v++)
-		if (v->playingChannel == channel && v->playingPreset != -1)
+		if (v->playingPreset != -1 && v->playingChannel == channel)
 			v->noteGainDB += gainDBChange;
 	c->gainDB = gainDB;
 }


### PR DESCRIPTION
This changes two conditionals to no longer occasionally evaluate in part based on uninitialized memory: only `presetIndex` is guaranteed to be set in some cases when it is `-1`, so that should be evaluated first to avoid hitting the other subconditions if not needed. While this couldn't possibly cause behavior or corruption issues as far as I can tell, it still might distract from legitimate errors in valgrind, libasan/sanitizer, etc., and generally just cause uncertainty for library users when it pops up.