### PR TITLE
Add "tsf_copy" function for linked copies (rebased)

### DIFF
--- a/tsf.h
+++ b/tsf.h
@@ -89,6 +89,12 @@ struct tsf_stream
 // Generic SoundFont loading method using the stream structure above
 TSFDEF tsf* tsf_load(struct tsf_stream* stream);
 
+// Copy a tsf instance from an existing one, use tsf_close to close it as well.
+// All copied tsf instances and their original instance are linked, and share the underlying soundfont.
+// This allows loading a soundfont only once, but using it for multiple independent playbacks.
+// (This function isn't thread-safe without locking.)
+TSFDEF tsf* tsf_copy(tsf* f);
+
 // Free the memory related to this tsf instance
 TSFDEF void tsf_close(tsf* f);
 
@@ -302,17 +308,18 @@ struct tsf
 	float* fontSamples;
 	struct tsf_voice* voices;
 	struct tsf_channels* channels;
-	float* outputSamples;
+	float** outputSamples;
 
 	int presetNum;
 	int voiceNum;
 	int maxVoiceNum;
-	int outputSampleSize;
+	int *outputSampleSize;
 	unsigned int voicePlayIndex;
 
 	enum TSFOutputMode outputmode;
 	float outSampleRate;
 	float globalGainDB;
+	int* refCount;
 };
 
 #ifndef TSF_NO_STDIO
@@ -1265,6 +1272,12 @@ TSFDEF tsf* tsf_load(struct tsf_stream* stream)
 		res->presets = (struct tsf_preset*)TSF_MALLOC(res->presetNum * sizeof(struct tsf_preset));
 		res->fontSamples = fontSamples;
 		res->outSampleRate = 44100.0f;
+		res->outputSamples = (float**)TSF_MALLOC(sizeof(float*));
+		*res->outputSamples = TSF_NULL;
+		res->outputSampleSize = (int*)TSF_MALLOC(sizeof(int));
+		*res->outputSampleSize = 0;
+		res->refCount = (int*)TSF_MALLOC(sizeof(int));
+		*res->refCount = 1;
 		fontSamples = TSF_NULL; //don't free below
 		tsf_load_presets(res, &hydra, fontSampleCount);
 	}
@@ -1275,17 +1288,40 @@ TSFDEF tsf* tsf_load(struct tsf_stream* stream)
 	return res;
 }
 
+TSFDEF tsf* tsf_copy(tsf* f)
+{
+	if (!f)
+		return TSF_NULL;
+
+	tsf* res = TSF_NULL;
+
+	res = (tsf*)TSF_MALLOC(sizeof(tsf));
+	memcpy(res, f, sizeof(tsf));
+	res->voices = TSF_NULL;
+	res->voiceNum = 0;
+	res->channels = TSF_NULL;
+	++(*res->refCount);
+
+	return res;
+}
+
 TSFDEF void tsf_close(tsf* f)
 {
 	struct tsf_preset *preset, *presetEnd;
 	if (!f) return;
-	for (preset = f->presets, presetEnd = preset + f->presetNum; preset != presetEnd; preset++)
-		TSF_FREE(preset->regions);
-	TSF_FREE(f->presets);
-	TSF_FREE(f->fontSamples);
+	if (--(*f->refCount) == 0)
+	{
+		for (preset = f->presets, presetEnd = preset + f->presetNum; preset != presetEnd; preset++)
+			TSF_FREE(preset->regions);
+		TSF_FREE(f->presets);
+		TSF_FREE(f->fontSamples);
+		TSF_FREE(*f->outputSamples);
+		TSF_FREE(f->outputSamples);
+		TSF_FREE(f->outputSampleSize);
+		TSF_FREE(f->refCount);
+	}
 	TSF_FREE(f->voices);
 	if (f->channels) { TSF_FREE(f->channels->channels); TSF_FREE(f->channels); }
-	TSF_FREE(f->outputSamples);
 	TSF_FREE(f);
 }
 
@@ -1482,16 +1518,16 @@ TSFDEF void tsf_render_short(tsf* f, short* buffer, int samples, int flag_mixing
 	float *floatSamples;
 	int channelSamples = (f->outputmode == TSF_MONO ? 1 : 2) * samples, floatBufferSize = channelSamples * sizeof(float);
 	short* bufferEnd = buffer + channelSamples;
-	if (floatBufferSize > f->outputSampleSize)
+	if (floatBufferSize > *f->outputSampleSize)
 	{
-		TSF_FREE(f->outputSamples);
-		f->outputSamples = (float*)TSF_MALLOC(floatBufferSize);
-		f->outputSampleSize = floatBufferSize;
+		TSF_FREE(*f->outputSamples);
+		*f->outputSamples = (float*)TSF_MALLOC(floatBufferSize);
+		*f->outputSampleSize = floatBufferSize;
 	}
 
-	tsf_render_float(f, f->outputSamples, samples, TSF_FALSE);
+	tsf_render_float(f, *f->outputSamples, samples, TSF_FALSE);
 
-	floatSamples = f->outputSamples;
+	floatSamples = *f->outputSamples;
 	if (flag_mixing) 
 		while (buffer != bufferEnd)
 		{


### PR DESCRIPTION
This adds a "tsf_copy" function for linked `tsf*` copies that share the underlying soundfont, which allows rendering out multiple independent playbacks with the same soundfont without loading it multiple times. It was originally written by @paladin-t (github.com/paladin-t), also see https://github.com/schellingb/TinySoundFont/pull/1 - GitHub wouldn't let me rebase the actual original commit to retain this info because it is apparently being complicated about deleted origin repos.

In my first tests, this causes a quite radical memory reduction for the soundfont I use (30MB on disk, but apparently larger in memory) by about 90MB of program memory used compared to just naively loading the soundfont twice for two parallel playbacks.

Please note however I did this rebase quite naively, this was e.g. also written before channels even were a thing. **So I'm not super confident it's error free, and doesn't have leaks or something.** However, my program *does* use channels and they appear to still work. But more eyes on it, and more testing might be helpful.

Closes #62 ...I think?