### PR TITLE
Convert attenuation from centibels to decibels

### DIFF
--- a/tsf.h
+++ b/tsf.h
@@ -1610,7 +1610,7 @@ TSFDEF int tsf_note_on(tsf* f, int preset_index, int key, float vel)
 		voice->playingPreset = preset_index;
 		voice->playingKey = key;
 		voice->playIndex = voicePlayIndex;
-		voice->noteGainDB = f->globalGainDB - region->attenuation - tsf_gainToDecibels(1.0f / vel);
+		voice->noteGainDB = f->globalGainDB - (region->attenuation / 10.0f) - tsf_gainToDecibels(1.0f / vel);
 
 		if (f->channels)
 		{

--- a/tsf.h
+++ b/tsf.h
@@ -647,7 +647,7 @@ static void tsf_region_operator(struct tsf_region* region, tsf_u16 genOper, unio
 						case GEN_FLOAT_LIMIT12K8K: vfactor =   1.0f; vmin = -12000.0f; vmax = 8000.0f; break;
 						case GEN_FLOAT_LIMIT1200:  vfactor =   1.0f; vmin =  -1200.0f; vmax = 1200.0f; break;
 						case GEN_FLOAT_LIMITPAN:   vfactor = 0.001f; vmin =     -0.5f; vmax =    0.5f; break;
-						case GEN_FLOAT_LIMITATTN:  vfactor =   0.1f; vmin =      0.0f; vmax =  144.0f; break;
+						case GEN_FLOAT_LIMITATTN:  vfactor =  0.01f; vmin =      0.0f; vmax =   14.4f; break;
 						case GEN_FLOAT_MAX1000:    vfactor =   1.0f; vmin =      0.0f; vmax = 1000.0f; break;
 						case GEN_FLOAT_MAX1440:    vfactor =   1.0f; vmin =      0.0f; vmax = 1440.0f; break;
 						default: continue;
@@ -1610,7 +1610,7 @@ TSFDEF int tsf_note_on(tsf* f, int preset_index, int key, float vel)
 		voice->playingPreset = preset_index;
 		voice->playingKey = key;
 		voice->playIndex = voicePlayIndex;
-		voice->noteGainDB = f->globalGainDB - (region->attenuation / 10.0f) - tsf_gainToDecibels(1.0f / vel);
+		voice->noteGainDB = f->globalGainDB - region->attenuation - tsf_gainToDecibels(1.0f / vel);
 
 		if (f->channels)
 		{


### PR DESCRIPTION
Attenuation is currently used as a decibel value. However, the SoundFont Technical Specification describes initialAttenuation as being in centibels. Due to this, regions with a nonzero attenuation value are much quieter than they should be. This simple fix divides the attenuation by 10 when calculating note gain to perform the conversion.

Note how the lead organ in this MIDI (about 20 seconds in) is far quieter before the change, but after the change, it much more closely resembles FluidSynth's output.

Before fix:

https://github.com/schellingb/TinySoundFont/assets/25674682/2851a4cd-eeea-44b2-a0bb-c11af4cbc8eb

After fix:

https://github.com/schellingb/TinySoundFont/assets/25674682/6277b128-fb02-4e28-b452-48d0fc46b7f8

FluidSynth for reference:

https://github.com/schellingb/TinySoundFont/assets/25674682/eeeb8753-4b5a-4e01-a617-81aae3241e9e
