### PR TITLE
cmake build targets for vcpkg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,18 +16,18 @@ set_property(
   TARGET TinySoundFont
   APPEND PROPERTY
   PUBLIC_HEADER "tml.h" "tsf.h")
-set_target_properties(TinySoundFont PROPERTIES OUTPUT_NAME tinysf)
+set_target_properties(TinySoundFont PROPERTIES OUTPUT_NAME tinysoundfont)
 set_target_properties(TinySoundFont PROPERTIES VERSION ${PROJECT_VERSION})
 
 install(
   TARGETS TinySoundFont
   EXPORT TinySoundFontTargets
   PUBLIC_HEADER
-    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/tinysf"
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/tinysoundfont"
     COMPONENT devel)
 install(
   EXPORT TinySoundFontTargets
-    DESTINATION "${CMAKE_INSTALL_DATADIR}/tinysf"
+    DESTINATION "${CMAKE_INSTALL_DATADIR}/tinysoundfont"
     COMPONENT devel)
 install(
   FILES "LICENSE" "README.md"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ set(PROJECT_SNAME "TinySoundFont")
 project(TinySoundFont VERSION "0.9")
 message(STATUS "version: ${PROJECT_VERSION}")
 include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
 
 add_library(TinySoundFont INTERFACE)
 target_include_directories(
@@ -18,14 +19,19 @@ set_property(
   PUBLIC_HEADER "tml.h" "tsf.h")
 set_target_properties(TinySoundFont PROPERTIES VERSION ${PROJECT_VERSION})
 
+write_basic_package_version_file(
+  "${PROJECT_NAME}ConfigVersion.cmake"
+  VERSION ${PROJECT_VERSION}
+  COMPATIBILITY SameMajorVersion)
+  
 install(
   TARGETS TinySoundFont
-  EXPORT TinySoundFontTargets
+  EXPORT TinySoundFontConfig
   PUBLIC_HEADER
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/tsf"
     COMPONENT devel)
 install(
-  EXPORT TinySoundFontTargets
+  EXPORT TinySoundFontConfig
     DESTINATION "${CMAKE_INSTALL_DATADIR}/tsf"
     COMPONENT devel)
 install(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,11 +3,19 @@
 cmake_minimum_required(VERSION 3.14)
 set(PROJECT_VENDOR "schellingb")
 set(PROJECT_SNAME "TinySoundFont")
-project(TinySoundFont VERSION "0.9.0")
+project(TinySoundFont VERSION "0.9")
 message(STATUS "version: ${PROJECT_VERSION}")
 include(GNUInstallDirs)
 
-add_library(TinySoundFont INTERFACE tml.h tsf.h)
+add_library(TinySoundFont INTERFACE)
+target_include_directories(
+  TinySoundFont INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:include>)
+set_property(
+  TARGET TinySoundFont
+  APPEND PROPERTY
+  PUBLIC_HEADER "tml.h" "tsf.h")
 set_target_properties(TinySoundFont PROPERTIES OUTPUT_NAME tinysf)
 set_target_properties(TinySoundFont PROPERTIES VERSION ${PROJECT_VERSION})
 
@@ -18,10 +26,9 @@ install(
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/tinysf"
     COMPONENT devel)
 install(
-  DIRECTORY "${CMAKE_BINARY_DIR}/etc/"
-  DESTINATION "${CMAKE_INSTALL_DATADIR}/tinysf"
-  COMPONENT devel
-  FILES_MATCHING PATTERN "*onfig*.cmake")
+  EXPORT TinySoundFontTargets
+    DESTINATION "${CMAKE_INSTALL_DATADIR}/tinysf"
+    COMPONENT devel)
 install(
   FILES "LICENSE" "README.md"
   TYPE DOC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,28 @@
+
+# config
+cmake_minimum_required(VERSION 3.14)
+set(PROJECT_VENDOR "schellingb")
+set(PROJECT_SNAME "TinySoundFont")
+project(TinySoundFont VERSION "0.9.0")
+message(STATUS "version: ${PROJECT_VERSION}")
+include(GNUInstallDirs)
+
+add_library(TinySoundFont INTERFACE tml.h tsf.h)
+set_target_properties(TinySoundFont PROPERTIES OUTPUT_NAME tinysf)
+set_target_properties(TinySoundFont PROPERTIES VERSION ${PROJECT_VERSION})
+
+install(
+  TARGETS TinySoundFont
+  EXPORT TinySoundFontTargets
+  PUBLIC_HEADER
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/tinysf"
+    COMPONENT devel)
+install(
+  DIRECTORY "${CMAKE_BINARY_DIR}/etc/"
+  DESTINATION "${CMAKE_INSTALL_DATADIR}/tinysf"
+  COMPONENT devel
+  FILES_MATCHING PATTERN "*onfig*.cmake")
+install(
+  FILES "LICENSE" "README.md"
+  TYPE DOC
+  COMPONENT runtime)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ set_property(
 set_target_properties(TinySoundFont PROPERTIES VERSION ${PROJECT_VERSION})
 
 write_basic_package_version_file(
-  "${PROJECT_NAME}ConfigVersion.cmake"
+  "TinySoundFontConfigVersion.cmake"
   VERSION ${PROJECT_VERSION}
   COMPATIBILITY SameMajorVersion)
   
@@ -32,8 +32,12 @@ install(
     COMPONENT devel)
 install(
   EXPORT TinySoundFontConfig
-    DESTINATION "${CMAKE_INSTALL_DATADIR}/tsf"
-    COMPONENT devel)
+  DESTINATION "${CMAKE_INSTALL_DATADIR}/tsf"
+  COMPONENT devel)
+install(
+  FILES "${CMAKE_BINARY_DIR}/TinySoundFontConfigVersion.cmake"
+  DESTINATION "${CMAKE_INSTALL_DATADIR}/tsf"
+  COMPONENT devel)
 install(
   FILES "LICENSE" "README.md"
   TYPE DOC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,18 +16,17 @@ set_property(
   TARGET TinySoundFont
   APPEND PROPERTY
   PUBLIC_HEADER "tml.h" "tsf.h")
-set_target_properties(TinySoundFont PROPERTIES OUTPUT_NAME tinysoundfont)
 set_target_properties(TinySoundFont PROPERTIES VERSION ${PROJECT_VERSION})
 
 install(
   TARGETS TinySoundFont
   EXPORT TinySoundFontTargets
   PUBLIC_HEADER
-    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/tinysoundfont"
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/tsf"
     COMPONENT devel)
 install(
   EXPORT TinySoundFontTargets
-    DESTINATION "${CMAKE_INSTALL_DATADIR}/tinysoundfont"
+    DESTINATION "${CMAKE_INSTALL_DATADIR}/tsf"
     COMPONENT devel)
 install(
   FILES "LICENSE" "README.md"


### PR DESCRIPTION
I have created a cmake buildfile that created build-targets for TinySoundFont. I am using this to allow the library dependency to be managed by vcpkg: https://github.com/Caldfir/vcpkg/tree/tinysf