### PR TITLE
Restore number of allocated voice slots on OOM error

### DIFF
--- a/tsf.h
+++ b/tsf.h
@@ -1604,7 +1604,7 @@ TSFDEF int tsf_note_on(tsf* f, int preset_index, int key, float vel)
 				struct tsf_voice* newVoices;
 				f->voiceNum += 4;
 				newVoices = (struct tsf_voice*)TSF_REALLOC(f->voices, f->voiceNum * sizeof(struct tsf_voice));
-				if (!newVoices) return 0;
+				if (!newVoices) { f->voiceNum -= 4; return 0; }
 				f->voices = newVoices;
 				voice = &f->voices[f->voiceNum - 4];
 				voice[1].playingPreset = voice[2].playingPreset = voice[3].playingPreset = -1;
@@ -2077,3 +2077,4 @@ TSFDEF float tsf_channel_get_tuning(tsf* f, int channel)
 #endif
 
 #endif //TSF_IMPLEMENTATION
+


### PR DESCRIPTION
When an OOM error happens when trying to allocate more slots for voices, tsf_note_on returned failure, properly, but it also didn't undo the increase in voiceNum (which didn't happen). This would cause an overflow/overwrite error on the next note_on call.

In most desktop systems this OOM isn't going to happen, but I'm using this on embedded CPUs with as little as 40KB of heap so there it does show up.