### PR TITLE
Set pitch wheel back to center on all_ctrl_off

### DIFF
--- a/tsf.h
+++ b/tsf.h
@@ -2015,6 +2015,7 @@ TSFDEF int tsf_channel_midi_control(tsf* f, int channel, int controller, int con
 			tsf_channel_set_pan(f, channel, 0.5f);
 			tsf_channel_set_pitchrange(f, channel, 2.0f);
 			tsf_channel_set_tuning(f, channel, 0);
+			tsf_channel_set_pitchwheel(f, channel, 8192);
 			return 1;
 	}
 	return 1;
@@ -2077,3 +2078,4 @@ TSFDEF float tsf_channel_get_tuning(tsf* f, int channel)
 #endif
 
 #endif //TSF_IMPLEMENTATION
+


### PR DESCRIPTION
I'm making a midi player, so have been testing out various midi files.
I came across one that had a pitch bend that was meant to return to center.

One control change it was getting producing was 0x79 (121) for resetting all controls.

On Windows Media Player, it sounded fine but not in the midi player i was writing which was calling `tsf_channel_midi_control` for this particular event.

After making this change, the midi playback now sounds fine, and the pitch bending heard in windows media player sounded identical to my ears. 

Without this change, the pitch would bend, and then stay bent until another pitch bend event.

Let me know if you need any further examples, or a video demo showing the before/after.