### PR TITLE
fix multi-track MIDI parsing when meta events have delta time 0

### DIFF
--- a/tml.h
+++ b/tml.h
@@ -373,11 +373,8 @@ static int tml_parsemessage(tml_message** f, struct tml_parser* p)
 		}
 	}
 
-	if (deltatime || evt->type)
-	{
-		evt->time = deltatime;
-		p->message_count++;
-	}
+	evt->time = deltatime;
+	p->message_count++;
 	return evt->type;
 }
 


### PR DESCRIPTION
The condition `if (deltatime || evt->type)` skipped storing messages when both deltatime and type were 0. This caused meta events at the start of tracks (key signature, time signature, track name, etc.) to be dropped, corrupting the delta time chain for subsequent notes.

This resulted in most notes being missed during playback for affected MIDI files. For example, https://frank-buss.de/tmp/bwv-846.mid has 548 note-on events but only 85 were being played. timidity plays this file correctly.

The fix removes the conditional and always stores parsed messages to preserve timing integrity.